### PR TITLE
Implement automatic batching for PutBatch

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -5,3 +5,6 @@ import "errors"
 // ErrNoItems is returned when we expect a query result to contain items,
 // but it doesn't contain any.
 var ErrNoItems error = errors.New("item query returned no items")
+
+// ErrInvalidBatchSize is returned if an invalid batch size is specified when creating a ddb instance.
+var ErrInvalidBatchSize error = errors.New("batch size must be greater than 0 and must not be greater than 25")


### PR DESCRIPTION
This PR adds automatic batch splitting to PutBatch.
DynamoDB has a limit of 25 items per batch, this change means that any amount of items can be passed to put batch and ddb will split the batches for you.

There is also a configuration override to adjust the batch size if needed