### PR TITLE
add delete method

### DIFF
--- a/ddbmock/mock.go
+++ b/ddbmock/mock.go
@@ -15,6 +15,8 @@ type Client struct {
 	t       TestReporter
 	mu      *sync.Mutex
 	results map[reflect.Type]mockResult
+	// DeleteErr causes Delete() to return an error if it is set
+	DeleteErr error
 	// PutErr causes Put() to return an error if it is set
 	PutErr error
 	// PutBatchErr causes PutBatch() to return an error if it is set
@@ -117,4 +119,8 @@ func (m *Client) PutBatch(ctx context.Context, items ...ddb.Keyer) error {
 
 func (m *Client) TransactWriteItems(ctx context.Context, tx []ddb.TransactWriteItem) error {
 	return m.TransactWriteItemsErr
+}
+
+func (m *Client) Delete(ctx context.Context, item ddb.Keyer) error {
+	return m.DeleteErr
 }

--- a/ddbtest/delete_integration_test.go
+++ b/ddbtest/delete_integration_test.go
@@ -1,0 +1,68 @@
+package ddbtest
+
+import (
+	"context"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/feature/dynamodb/attributevalue"
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
+	"github.com/common-fate/ddb"
+	"github.com/stretchr/testify/assert"
+)
+
+type GetThing struct {
+	Type   string
+	ID     string
+	Result *Thing `ddb:"result"`
+}
+
+func (g *GetThing) BuildQuery() (*dynamodb.QueryInput, error) {
+	qi := dynamodb.QueryInput{
+		KeyConditionExpression: aws.String("PK = :pk and SK = :sk"),
+		ExpressionAttributeValues: map[string]types.AttributeValue{
+			":pk": &types.AttributeValueMemberS{Value: g.Type},
+			":sk": &types.AttributeValueMemberS{Value: g.ID},
+		},
+	}
+	return &qi, nil
+}
+
+func (g *GetThing) UnmarshalQueryOutput(out *dynamodb.QueryOutput) error {
+	if len(out.Items) != 1 {
+		return ddb.ErrNoItems
+	}
+
+	return attributevalue.UnmarshalMap(out.Items[0], &g.Result)
+}
+
+func TestDeleteIntegration(t *testing.T) {
+	c := getTestClient(t)
+	ctx := context.Background()
+
+	// insert fixture data
+	a := Thing{
+		Type:  randomString(20),
+		ID:    randomString(20),
+		Color: "red",
+	}
+	PutFixtures(t, c, a)
+
+	// verify the fixture is in the table
+	q := &GetThing{Type: a.Type, ID: a.ID}
+	err := c.Query(ctx, q)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = c.Delete(ctx, a)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// verify the fixture has been deleted
+	q = &GetThing{Type: a.Type, ID: a.ID}
+	err = c.Query(ctx, q)
+	assert.Equal(t, ddb.ErrNoItems, err)
+}

--- a/delete.go
+++ b/delete.go
@@ -1,0 +1,31 @@
+package ddb
+
+import (
+	"context"
+
+	"github.com/aws/aws-sdk-go-v2/feature/dynamodb/attributevalue"
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
+)
+
+// Delete calls DeleteItem to delete an item in DynamoDB.
+func (c *Client) Delete(ctx context.Context, item Keyer) error {
+	keys, err := item.DDBKeys()
+	if err != nil {
+		return err
+	}
+
+	keyAttrs, err := attributevalue.MarshalMap(keys)
+	if err != nil {
+		return err
+	}
+
+	_, err = c.client.DeleteItem(ctx, &dynamodb.DeleteItemInput{
+		Key: map[string]types.AttributeValue{
+			"PK": keyAttrs["PK"],
+			"SK": keyAttrs["SK"],
+		},
+		TableName: &c.table,
+	})
+	return err
+}

--- a/interface.go
+++ b/interface.go
@@ -9,4 +9,5 @@ type Storage interface {
 	Put(ctx context.Context, item Keyer) error
 	PutBatch(ctx context.Context, items ...Keyer) error
 	TransactWriteItems(ctx context.Context, tx []TransactWriteItem) error
+	Delete(ctx context.Context, item Keyer) error
 }


### PR DESCRIPTION
Calling the `client.Delete()` method will remove an item from DynamoDB. Also adds an integration test around the new method.