### PR TITLE
Add Client method to drop down into the raw DynamoDB client

### DIFF
--- a/client.go
+++ b/client.go
@@ -81,3 +81,7 @@ func WithPageTokenizer(e Tokenizer) func(*Client) {
 func (c *Client) Client() *dynamodb.Client {
 	return c.client
 }
+
+func (c *Client) Table() string {
+	return c.table
+}

--- a/client.go
+++ b/client.go
@@ -77,3 +77,7 @@ func WithPageTokenizer(e Tokenizer) func(*Client) {
 		c.tokenizer = e
 	}
 }
+
+func (c *Client) Client() *dynamodb.Client {
+	return c.client
+}

--- a/ddbmock/mock.go
+++ b/ddbmock/mock.go
@@ -5,6 +5,7 @@ import (
 	"reflect"
 	"sync"
 
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
 	"github.com/common-fate/ddb"
 )
 
@@ -206,4 +207,11 @@ func (m *Client) DeleteBatch(ctx context.Context, items ...ddb.Keyer) error {
 
 func (m *Client) NewTransaction() ddb.Transaction {
 	return &MockTransaction{ExecuteError: m.TransactionExecuteErr}
+}
+
+// Client returns nil. If you're writing tests which use
+// DynamoDB implementation details you should probably be
+// using integration tests!
+func (m *Client) Client() *dynamodb.Client {
+	return nil
 }

--- a/ddbmock/mock.go
+++ b/ddbmock/mock.go
@@ -215,3 +215,7 @@ func (m *Client) NewTransaction() ddb.Transaction {
 func (m *Client) Client() *dynamodb.Client {
 	return nil
 }
+
+func (m *Client) Table() string {
+	return ""
+}

--- a/interface.go
+++ b/interface.go
@@ -1,6 +1,10 @@
 package ddb
 
-import "context"
+import (
+	"context"
+
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
+)
 
 // Storage defines a common interface to make testing ddb easier.
 // Both the real and mock clients meet this interface.
@@ -19,6 +23,9 @@ type Storage interface {
 	// 	var item MyItem
 	//	db.Get(ctx, ddb.GetKey{PK: ..., SK: ...}, &item)
 	Get(ctx context.Context, key GetKey, item Keyer, opts ...func(*GetOpts)) (*GetItemResult, error)
+	// Client returns the underlying DynamoDB client. It's useful for cases
+	// where you need more control over queries or writes than the ddb library provides.
+	Client() *dynamodb.Client
 }
 
 // Transactions allow atomic write operations to be made to a DynamoDB table.

--- a/interface.go
+++ b/interface.go
@@ -26,6 +26,8 @@ type Storage interface {
 	// Client returns the underlying DynamoDB client. It's useful for cases
 	// where you need more control over queries or writes than the ddb library provides.
 	Client() *dynamodb.Client
+	// Table returns the name of the DynamoDB table that the client is configured to use.
+	Table() string
 }
 
 // Transactions allow atomic write operations to be made to a DynamoDB table.


### PR DESCRIPTION
Adds a `Client()` method which gives the underlying `dynamodb` client. Allows users to drop out of our abstractions and just make regular DynamoDB API calls without having to maintain a separate DynamoDB client.

```go
db, _ := ddb.NewClient(ctx, "my-table")
client := db.Client()
```

Also adds a `Table()` method so when using `Client()` you know which table to operate on.